### PR TITLE
Add initial PeekDock tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
 # PeekDock
-PeekDock-Py is a lightweight Python/Qt tool that lets you drag any open window into a dedicated “peek dock” and keep a live, scaled-down thumbnail on screen. It’s the perfect middle ground between leaving an app fully open and sending it to the task-bar.
+
+PeekDock is a small Python/Qt application that provides a translucent dock window. You can drag entries representing other windows into this dock so they remain visible as small thumbnails instead of being fully minimized.
+
+## Features
+- Semi-transparent, resizable main window
+- List of all visible windows on the system
+- Drag an entry from the list into the dock area to embed the window
+- Each docked window stays live in a smaller form
+
+### Requirements
+- Windows 10/11
+- Python 3.9 or newer
+- Packages: `PyQt5`, `pywin32`
+
+### Run from source
+```bash
+pip install PyQt5 pywin32
+python main.py
+```
+
+### Create a single executable
+Install PyInstaller and build:
+```bash
+pip install pyinstaller
+pyinstaller --noconsole --onefile main.py
+```
+The generated `dist/main.exe` can run without Python installed.
+
+---
+
+# PeekDock 中文说明
+
+PeekDock 是一个使用 Python 与 Qt 编写的小工具，提供一个半透明的停靠窗口，可以把其他窗口以缩略图形式放在其中，既不会完全缩到任务栏，也不会占满桌面。
+
+## 功能
+- 可调大小的半透明主窗口
+- 自动列出当前系统可见窗口
+- 将列表中的窗口条目拖入中央区域即可收纳
+- 收纳后的窗口依旧保持实时显示
+
+### 运行要求
+- Windows 10/11
+- Python 3.9 及以上
+- 依赖库：`PyQt5`、`pywin32`
+
+### 源码运行
+```bash
+pip install PyQt5 pywin32
+python main.py
+```
+
+### 打包为单一 exe
+安装 PyInstaller 后执行：
+```bash
+pip install pyinstaller
+pyinstaller --noconsole --onefile main.py
+```
+在 `dist/main.exe` 即可得到独立的可执行文件。
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,112 @@
+import sys
+
+# Only run on Windows
+if sys.platform != 'win32':
+    raise SystemExit('PeekDock currently supports Windows only.')
+
+from PyQt5 import QtWidgets, QtGui, QtCore
+import win32gui
+import win32con
+
+
+def enum_windows():
+    """Return list of (title, handle) tuples for visible windows."""
+    results = []
+
+    def callback(hwnd, extra):
+        if win32gui.IsWindowVisible(hwnd):
+            title = win32gui.GetWindowText(hwnd)
+            if title:
+                results.append((title, hwnd))
+        return True
+
+    win32gui.EnumWindows(callback, None)
+    return results
+
+
+class WindowListWidget(QtWidgets.QListWidget):
+    """List widget showing open windows."""
+
+    def refresh(self):
+        self.clear()
+        for title, hwnd in enum_windows():
+            item = QtWidgets.QListWidgetItem(title)
+            item.setData(QtCore.Qt.UserRole, hwnd)
+            self.addItem(item)
+
+
+class DockArea(QtWidgets.QMdiArea):
+    """Area that accepts window handles to dock."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+        self.docked = {}
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasFormat('application/x-peekdock-hwnd'):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event):
+        data = event.mimeData().data('application/x-peekdock-hwnd')
+        hwnd = int(data.data().decode())
+        self.dock_window(hwnd)
+        event.acceptProposedAction()
+
+    def dock_window(self, hwnd):
+        if hwnd in self.docked:
+            return
+        title = win32gui.GetWindowText(hwnd)
+        window = QtGui.QWindow.fromWinId(hwnd)
+        container = QtWidgets.QWidget.createWindowContainer(window)
+        sub = self.addSubWindow(container)
+        sub.setWindowTitle(title)
+        sub.resize(200, 150)
+        sub.show()
+        self.docked[hwnd] = (window, container, sub)
+        # set parent at OS level
+        win32gui.SetParent(hwnd, int(container.winId()))
+        style = win32gui.GetWindowLong(hwnd, win32con.GWL_STYLE)
+        style = style & ~win32con.WS_POPUP | win32con.WS_CHILD
+        win32gui.SetWindowLong(hwnd, win32con.GWL_STYLE, style)
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle('PeekDock')
+        self.setWindowOpacity(0.8)
+        self.resize(800, 600)
+
+        self.list_widget = WindowListWidget()
+        self.list_widget.refresh()
+
+        dock_widget = QtWidgets.QDockWidget('Windows', self)
+        dock_widget.setWidget(self.list_widget)
+        self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, dock_widget)
+
+        self.dock_area = DockArea()
+        self.setCentralWidget(self.dock_area)
+
+        self.list_widget.itemPressed.connect(self.start_drag)
+
+    def start_drag(self, item):
+        hwnd = item.data(QtCore.Qt.UserRole)
+        mime = QtCore.QMimeData()
+        mime.setData('application/x-peekdock-hwnd', str(hwnd).encode())
+        drag = QtGui.QDrag(self.list_widget)
+        drag.setMimeData(mime)
+        drag.exec_(QtCore.Qt.MoveAction)
+
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    win = MainWindow()
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python/Qt implementation for `PeekDock`
- document usage and build steps in Chinese and English

## Testing
- `python3 main.py` (fails on non-Windows)
- `pyinstaller --noconsole --onefile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6867cbddc68c8332ba3d65b4d4128b0e